### PR TITLE
Reduce image size by ~1.5GB, expose logs as volume

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.swp
 .DS_Store
 build/*.zip
+build/p*-5.4*
+build/*ee-5.4*


### PR DESCRIPTION
Amazingly enough, pre-unarchiving the Pentaho files and being more judicious with `chown` statements results in an image that's almost 2GB smaller than before. I'm leaving extraction steps in the Dockerfile in case anyone still wants to use them, just commented out.